### PR TITLE
metadata fixes

### DIFF
--- a/pkg/czid/metadata_test.go
+++ b/pkg/czid/metadata_test.go
@@ -14,11 +14,10 @@ func TestCSVMetadata(t *testing.T) {
 	}
 	defer os.Remove(csv.Name())
 
-	csvData := []byte(`Sample Name\u200b,Host Genome,collection_location,Nucleotide Type
-sample one,Human,"California, USA",DNA
-
-sample two,D\u200bog,"California, USA",RNA
-`)
+	csvData := []byte("Sample Name\u200b,Host Genome,collection_location,Nucleotide Type\n" +
+		"sample one,Human,\"California, USA\",DNA\n\n" +
+		"sample two,D\u200bog,\"California, USA\",RNA",
+	)
 
 	_, err = csv.Write(csvData)
 	if err != nil {

--- a/pkg/czid/metadata_test.go
+++ b/pkg/czid/metadata_test.go
@@ -14,9 +14,10 @@ func TestCSVMetadata(t *testing.T) {
 	}
 	defer os.Remove(csv.Name())
 
-	csvData := []byte(`Sample Name,Host Genome,collection_location,Nucleotide Type
+	csvData := []byte(`Sample Name\u200b,Host Genome,collection_location,Nucleotide Type
 sample one,Human,"California, USA",DNA
-sample two,Dog,"California, USA",RNA
+
+sample two,D\u200bog,"California, USA",RNA
 `)
 
 	_, err = csv.Write(csvData)

--- a/pkg/czid/uploadSamplesFlow.go
+++ b/pkg/czid/uploadSamplesFlow.go
@@ -42,11 +42,21 @@ func UploadSamplesFlow(
 			}
 		}
 	}
+	missing := false
 	for sampleName := range sampleFiles {
 		if _, hasMetadata := samplesMetadata[sampleName]; !hasMetadata {
-			samplesMetadata[sampleName] = NewMetadata(map[string]string{})
+			if metadataCSVPath != "" {
+				samplesMetadata[sampleName] = NewMetadata(map[string]string{})
+			} else {
+				log.Printf("missing metadata in metadata CSV for sample name '%s'\n", sampleName)
+				missing = true
+			}
 		}
 	}
+	if missing {
+		log.Fatal("missing metadata in CSV for samples")
+	}
+
 	for sampleName, m := range samplesMetadata {
 		samplesMetadata[sampleName] = m.Fuse(metadata)
 	}


### PR DESCRIPTION
Adds a few QOL things with regards to metadata:

- Remove hidden characters
- If a metadata CSV is provided and one of your samples isn't found in it it will throw an error with the missing sample name
- Ignores blank lines in the CSV. Some users seem to put an extra newline in their CSVs, easy enough to ignore