### PR TITLE
Increase Logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			log.Fatal("Error reading config file: %s\n", err.Error())
+			log.Fatalf("Error reading config file: %s\n", err.Error())
 		} else if verbose {
 			fmt.Println("Config file not found. Run the command with '--config' to explicitly pass in a config.yaml file. Or set environment variables with the prefix CZID_CLI_* (eg CZID_CLI_SECRET)")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,15 +57,18 @@ func initConfig() {
 		viper.SetConfigFile(path.Join(configDir, "config.yaml"))
 	}
 
+	// Check if verbose flag is set
+	verbose, _ := RootCmd.Flags().GetBool("verbose")
+	
 	viper.SetEnvPrefix("czid_cli")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			fmt.Printf("Error reading config file: %s\n", err.Error())
-		} else {
-			fmt.Println(`Warning: config file not found. Run the command with "--config" to explicitly pass in a config file. Or set environment variables with the prefix CZID_CLI_* (eg CZID_CLI_SECRET)`)
+			log.Fatal("Error reading config file: %s\n", err.Error())
+		} else if verbose {
+			fmt.Println("Config file not found. Run the command with '--config' to explicitly pass in a config.yaml file. Or set environment variables with the prefix CZID_CLI_* (eg CZID_CLI_SECRET)")
 		}
 
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,9 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			fmt.Printf("Error reading config file: %s\n", err.Error())
+		} else {
+			fmt.Println(`Warning: config file not found. Run the command with "--config" to explicitly pass in a config file. Or set environment variables with the prefix CZID_CLI_* (eg CZID_CLI_SECRET)`)
 		}
+
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"runtime"
 	"sync"
-
 	"github.com/spf13/viper"
 )
 
@@ -27,19 +26,19 @@ func MkdirIfNotExists(dirname string) error {
 
 // GetConfigDir gets the config directory for this application
 func GetConfigDir() (string, error) {
-	userCacheDir, err := os.UserConfigDir()
+	userConfigDir, err := os.UserConfigDir()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
-	cacheDir := path.Join(userCacheDir, AppName)
-	return cacheDir, MkdirIfNotExists(cacheDir)
+	configDir := path.Join(userConfigDir, AppName)
+	return configDir, MkdirIfNotExists(configDir)
 }
 
 // GetCacheDir gets the cache directory for this application
 func GetCacheDir() (string, error) {
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	cacheDir := path.Join(userCacheDir, AppName)
 	return cacheDir, MkdirIfNotExists(cacheDir)


### PR DESCRIPTION
* if config file is not found, prints a warning message but does not fail so variables can be loaded as environment variables. This will run even if the user is running `czid login` so I've hidden it behind a verbose flag to avoid confusion
* fails if config folder is unable to get created (e.g permissions issues)
* fails if cache folder is unable to get created 