### PR TITLE
concatenate lanes

### DIFF
--- a/pkg/czid/local.go
+++ b/pkg/czid/local.go
@@ -2,12 +2,12 @@ package czid
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 var inputExp = regexp.MustCompile(`\.(fasta|fa|fastq|fq)(\.gz)?$`)
@@ -37,7 +37,7 @@ func IsR2(path string) bool {
 func extractLaneNumber(path string) (int, error) {
 	match := sampleNameExp.FindString(path)
 	if len(match) < 5 {
-		log.Fatalf("path has no lane number %s", path)
+		return 0, fmt.Errorf("path has no lane number %s", path)
 	}
 
 	n, err := strconv.Atoi(match[2:5])
@@ -45,6 +45,15 @@ func extractLaneNumber(path string) (int, error) {
 		return n, fmt.Errorf("path has no lane number %s", path)
 	}
 	return n, nil
+}
+
+func StripLaneNumber(path string) string {
+	match := sampleNameExp.FindString(path)
+	if len(match) < 5 {
+		return path
+	}
+
+	return sampleNameExp.ReplaceAllString(path, "") + match[5:]
 }
 
 type SampleFiles struct {
@@ -117,14 +126,17 @@ func SamplesFromDir(directory string, verbose bool) (map[string]SampleFiles, err
 
 		if len(pair.R1) > 1 {
 			sort.Strings(pair.R1)
+			fmt.Printf("concatenating lane files: %s\n", strings.Join(pair.R1, ", "))
 		}
 
 		if len(pair.R2) > 1 {
 			sort.Strings(pair.R2)
+			fmt.Printf("concatenating lane files: %s\n", strings.Join(pair.R2, ", "))
 		}
 
 		if len(pair.Single) > 1 {
 			sort.Strings(pair.Single)
+			fmt.Printf("concatenating lane files: %s\n", strings.Join(pair.Single, ", "))
 		}
 
 		if len(pair.R1) > 0 && len(pair.R2) > 0 {

--- a/pkg/czid/local.go
+++ b/pkg/czid/local.go
@@ -36,7 +36,7 @@ func IsR2(path string) bool {
 
 func extractLaneNumber(path string) (int, error) {
 	match := sampleNameExp.FindString(path)
-	if len(match) < 5 {
+	if len(match) < 5 || !strings.HasPrefix(match, "_L") {
 		return 0, fmt.Errorf("path has no lane number %s", path)
 	}
 
@@ -49,7 +49,7 @@ func extractLaneNumber(path string) (int, error) {
 
 func StripLaneNumber(path string) string {
 	match := sampleNameExp.FindString(path)
-	if len(match) < 5 {
+	if len(match) < 5 || !strings.HasPrefix(match, "_L") {
 		return path
 	}
 

--- a/pkg/czid/local_test.go
+++ b/pkg/czid/local_test.go
@@ -116,3 +116,11 @@ func TestSamplesFromDirPairAndSingle(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestStripLaneNumber(t *testing.T) {
+	newPath := StripLaneNumber("ABC_L001_R1.fasta")
+
+	if newPath != "ABC_R1.fasta" {
+		t.Errorf("'%s' != '%s'", newPath, "ABC_R1.fasta")
+	}
+}

--- a/pkg/czid/local_test.go
+++ b/pkg/czid/local_test.go
@@ -123,4 +123,10 @@ func TestStripLaneNumber(t *testing.T) {
 	if newPath != "ABC_R1.fasta" {
 		t.Errorf("'%s' != '%s'", newPath, "ABC_R1.fasta")
 	}
+
+	newPath = StripLaneNumber("ABC_R1.fasta")
+
+	if newPath != "ABC_R1.fasta" {
+		t.Errorf("'%s' != '%s'", newPath, "ABC_R1.fasta")
+	}
 }

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -71,11 +71,10 @@ func (c *Client) CreateSamples(
 	for sampleName := range samplesMetadata {
 		files := sampleFiles[sampleName]
 		var filenames []string
-		// TODO concat files instead of using first
 		if len(files.Single) > 0 {
-			filenames = []string{files.Single[0]}
+			filenames = []string{StripLaneNumber(files.Single[0])}
 		} else {
-			filenames = []string{files.R1[0], files.R2[0]}
+			filenames = []string{StripLaneNumber(files.R1[0]), StripLaneNumber(files.R2[0])}
 		}
 
 		sample := createSamplesReqSample{

--- a/pkg/czid/uploadSamplesFlow.go
+++ b/pkg/czid/uploadSamplesFlow.go
@@ -135,7 +135,7 @@ func UploadSamplesFlow(
 					allFilenames = append(allFilenames, StripLaneNumber(sF.Single[0]))
 				}
 
-				return fmt.Errorf("s3 path %s did not match any of %s", inputFile.S3Path, strings.Join(filenames, ", "))
+				return fmt.Errorf("s3 path %s did not match any of %s", inputFile.S3Path, strings.Join(allFilenames, ", "))
 			}
 			err := u.UploadFiles(filenames, inputFile.S3Path, inputFile.MultipartUploadId)
 			if err != nil {

--- a/pkg/czid/uploadSamplesFlow.go
+++ b/pkg/czid/uploadSamplesFlow.go
@@ -116,29 +116,28 @@ func UploadSamplesFlow(
 		u := upload.NewUploader(credentials, disableBuffer)
 		sF := sampleFiles[sample.Name]
 		for _, inputFile := range sample.InputFiles {
-			filename := ""
-			// TODO use concat file instead of picking first file
-			if len(sF.R1) > 0 && filepath.Base(sF.R1[0]) == filepath.Base(inputFile.S3Path) {
-				filename = sF.R1[0]
-			} else if len(sF.R2) > 0 && filepath.Base(sF.R2[0]) == filepath.Base(inputFile.S3Path) {
-				filename = sF.R2[0]
+			var filenames []string
+			if len(sF.R1) > 0 && filepath.Base(StripLaneNumber(sF.R1[0])) == filepath.Base(inputFile.S3Path) {
+				filenames = sF.R1
+			} else if len(sF.R2) > 0 && filepath.Base(StripLaneNumber(sF.R2[0])) == filepath.Base(inputFile.S3Path) {
+				filenames = sF.R2
 			} else if len(sF.Single) > 0 && filepath.Base(sF.Single[0]) == filepath.Base(inputFile.S3Path) {
-				filename = sF.Single[0]
+				filenames = sF.Single
 			} else {
-				filenames := []string{}
+				allFilenames := []string{}
 				if len(sF.R1) > 0 {
-					filenames = append(filenames, sF.R1[0])
+					allFilenames = append(allFilenames, StripLaneNumber(sF.R1[0]))
 				}
 				if len(sF.R2) > 0 {
-					filenames = append(filenames, sF.R2[0])
+					allFilenames = append(allFilenames, StripLaneNumber(sF.R2[0]))
 				}
 				if len(sF.Single) > 0 {
-					filenames = append(filenames, sF.Single[0])
+					allFilenames = append(allFilenames, StripLaneNumber(sF.Single[0]))
 				}
 
 				return fmt.Errorf("s3 path %s did not match any of %s", inputFile.S3Path, strings.Join(filenames, ", "))
 			}
-			err := u.UploadFile(filename, inputFile.S3Path, inputFile.MultipartUploadId)
+			err := u.UploadFiles(filenames, inputFile.S3Path, inputFile.MultipartUploadId)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -1,7 +1,6 @@
 package upload
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -126,12 +125,7 @@ func (u *Uploader) UploadFiles(filenames []string, s3path string, multipartUploa
 	input := s3.PutObjectInput{
 		Bucket: &parsedPath.Host,
 		Key:    &key,
-		Body:   bufio.NewReader(reader),
-	}
-
-	if size <= 1024*1024*5 {
-		_, err := u.client.PutObject(context.Background(), &input)
-		return err
+		Body:   reader,
 	}
 
 	_, err = u.client.HeadObject(context.Background(), &s3.HeadObjectInput{

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -1,14 +1,17 @@
 package upload
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -92,17 +95,26 @@ func (u *Uploader) runProgressBar(fileSize int64) {
 	}
 }
 
-func (u *Uploader) UploadFile(filename string, s3path string, multipartUploadId *string) error {
-	f, err := os.Open(filename)
-	if err != nil {
-		return err
+func (u *Uploader) UploadFiles(filenames []string, s3path string, multipartUploadId *string) error {
+	size := int64(0)
+	for _, filename := range filenames {
+		stat, err := os.Stat(filename)
+		if err != nil {
+			return err
+		}
+		size += stat.Size()
 	}
-	defer f.Close()
 
-	stat, err := f.Stat()
-	if err != nil {
-		return err
+	readers := make([]io.Reader, len(filenames))
+	for i, filename := range filenames {
+		var err error
+		readers[i], err = os.Open(filename)
+		if err != nil {
+			return err
+		}
 	}
+
+	reader := io.MultiReader(readers...)
 
 	parsedPath, err := url.Parse(s3path)
 	if err != nil {
@@ -114,11 +126,10 @@ func (u *Uploader) UploadFile(filename string, s3path string, multipartUploadId 
 	input := s3.PutObjectInput{
 		Bucket: &parsedPath.Host,
 		Key:    &key,
-		Body:   f,
+		Body:   bufio.NewReader(reader),
 	}
 
-	if stat.Size() <= 1024*1024*5 {
-		input.Body = manager.NewBufferedReadSeeker(f, make([]byte, 1024*1024*2))
+	if size <= 1024*1024*5 {
 		_, err := u.client.PutObject(context.Background(), &input)
 		return err
 	}
@@ -138,28 +149,28 @@ func (u *Uploader) UploadFile(filename string, s3path string, multipartUploadId 
 			return err
 		}
 	} else {
-		fmt.Printf("skipping upload of %s, already uploaded\n", filename)
+		fmt.Printf("skipping upload of %s: already uploaded\n", strings.Join(filenames, ", "))
 		return nil
 	}
 
 	u.c.parts = make(chan int64)
 	defer close(u.c.parts)
 
-	go u.runProgressBar(stat.Size())
+	go u.runProgressBar(size)
 
 	if multipartUploadId != nil {
-		fmt.Printf("resuming upload of %s\n", filename)
+		fmt.Printf("resuming upload of %s\n", strings.Join(filenames, ", "))
 		_, err = u.u.ResumeUpload(context.Background(), &input, multipartUploadId)
 		if err != nil {
 			fmt.Println("could not resume upload, starting fresh upload")
 			close(u.c.parts)
 			u.c.parts = make(chan int64)
 			defer close(u.c.parts)
-			go u.runProgressBar(stat.Size())
+			go u.runProgressBar(size)
 			_, err = u.u.Upload(context.Background(), &input)
 		}
 	} else {
-		fmt.Printf("starting upload of %s\n", filename)
+		fmt.Printf("starting upload of %s\n", strings.Join(filenames, ", "))
 		_, err = u.u.Upload(context.Background(), &input)
 	}
 	return err


### PR DESCRIPTION
Pretty straightforward overall. A few highlights:

- For the filenames sent to the back end I am using the filenames with the lane number stripped
- I am logging to the user all groups of concatenated files
- For some reason I only buffered small files with this weird seekable buffer that comes with the S3 API. This may be a bit more optimal but upload doesn't require the file to be seekable so I just wrapped the reader in a buffer for a bit of a performance boost in all cases because the multireader isn't seekable.
- I compute the total size by getting the stat of every file