### PR TITLE
fall back to plain text locations if no location suggestion is found

### DIFF
--- a/pkg/czid/metadata.go
+++ b/pkg/czid/metadata.go
@@ -77,6 +77,8 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 	}
 	if m.CollectionLocation != (GeoSearchSuggestion{}) {
 		interfaceMap["Collection Location"] = m.CollectionLocation
+	} else if m.rawCollectionLocation != "" {
+		interfaceMap["Collection Location"] = m.rawCollectionLocation
 	}
 
 	return json.Marshal(interfaceMap)
@@ -212,7 +214,7 @@ func GeoSearchSuggestions(samplesMetadata *SamplesMetadata) error {
 	}
 
 	for o, n := range remapping {
-		if o != n.String() {
+		if o != n.String() && n != (GeoSearchSuggestion{}) {
 			fmt.Printf("  replacing location \"%s\" with \"%s\"\n", o, n.String())
 		}
 	}

--- a/pkg/czid/metadata_test.go
+++ b/pkg/czid/metadata_test.go
@@ -3,6 +3,7 @@ package czid
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -177,5 +178,31 @@ func TestJSONMarshal(t *testing.T) {
 
 	if _, has := mapM["collection_location"]; has {
 		t.Error("expected JSON format to filter out collection_location but it did not")
+	}
+}
+
+func TestFallbackToRawMetadataWithNoSuggestion(t *testing.T) {
+	m := NewMetadata(map[string]string{
+		"host_genome":         "Koala",
+		"collection_location": "Unknown",
+		"Water Control":       "No",
+		"Nucleotide Type":     "DNA",
+	})
+
+	if m.rawCollectionLocation != "Unknown" {
+		t.Fatalf("collection_location 'Unknown' should have been extracted into rawCollectionLocation but it was '%s'", m.rawCollectionLocation)
+	}
+
+	if m.CollectionLocation != (GeoSearchSuggestion{}) {
+		t.Fatalf("CollectionLocation should not be populated bit it was: %s", m.CollectionLocation)
+	}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(b), "Unknown") {
+		t.Fatalf("")
 	}
 }


### PR DESCRIPTION
Ticket: https://app.shortcut.com/idseq/story/229117/user-reports-bug-in-cli

In the web application if no location suggestion is found we allow the user to enter plain text. This behavior was not implemented in the CLI, instead the location is considered missing. This PR adds that behavior to bring the behaviors together.