### PR TITLE
Add file_type parameter to input_files

### DIFF
--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -61,7 +61,7 @@ type FileType string
 const (
 	FASTQFileType FileType = "fastq"
 	PrimerBedFileType FileType = "primer_bed"
-	ReferenceAccessionFileType FileType = "ref_seq"
+	ReferenceAccessionFileType FileType = "reference_sequence"
 )
 
 // CreateSamples creates samples on the back end and returns the necessary information to upload their files
@@ -118,7 +118,7 @@ func (c *Client) CreateSamples(
 			sample.ClearLabs = &sampleOptions.ClearLabs
 		}
 
-		var filetype FileType
+		filetype := FASTQFileType
 
 		if sampleOptions.ReferenceAccession != "" {
 			sample.ReferenceAccession = &sampleOptions.ReferenceAccession
@@ -128,7 +128,7 @@ func (c *Client) CreateSamples(
 		if sampleOptions.ReferenceFasta != "" {
 			referenceFasta := filepath.Base(sampleOptions.ReferenceFasta)
 			sample.ReferenceFasta = &referenceFasta
-			filetype = FASTQFileType
+			filetype = ReferenceAccessionFileType
 		}
 
 		if sampleOptions.PrimerBed != "" {

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -9,7 +9,7 @@ import (
 )
 
 type createSamplesReqInputFile struct {
-	FileType	 FileType `json:"file_type"`
+	FileType	 string `json:"file_type"`
 	Name         string `json:"name"`
 	Parts        string `json:"parts"`
 	Source       string `json:"source"`

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -138,7 +138,7 @@ func (c *Client) CreateSamples(
 
 		for i, filename := range filenames {
 			sample.InputFileAttributes[i] = createSamplesReqInputFile{
-				FileType:	  filetype,
+				FileType:	  string(filetype),
 				Name:         filepath.Base(filename),
 				Parts:        filepath.Base(filename),
 				Source:       filepath.Base(filename),

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -56,6 +56,7 @@ type UploadInfo struct {
 	S3Path            string  `json:"s3_path"`
 }
 
+// Must match file type constants present in CZID's InputFile model
 type FileType string
 const (
 	FASTQFileType FileType = "fastq"

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -9,6 +9,7 @@ import (
 )
 
 type createSamplesReqInputFile struct {
+	FileType	 FileType `json:"file_type"`
 	Name         string `json:"name"`
 	Parts        string `json:"parts"`
 	Source       string `json:"source"`
@@ -54,6 +55,13 @@ type UploadInfo struct {
 	MultipartUploadId *string `json:"multipart_upload_id"`
 	S3Path            string  `json:"s3_path"`
 }
+
+type FileType string
+const (
+	FASTQFileType FileType = "fastq"
+	PrimerBedFileType FileType = "primer_bed"
+	ReferenceAccessionFileType FileType = "ref_seq"
+)
 
 // CreateSamples creates samples on the back end and returns the necessary information to upload their files
 func (c *Client) CreateSamples(
@@ -109,22 +117,28 @@ func (c *Client) CreateSamples(
 			sample.ClearLabs = &sampleOptions.ClearLabs
 		}
 
+		var filetype FileType
+
 		if sampleOptions.ReferenceAccession != "" {
 			sample.ReferenceAccession = &sampleOptions.ReferenceAccession
+			filetype = ReferenceAccessionFileType
 		}
 
 		if sampleOptions.ReferenceFasta != "" {
 			referenceFasta := filepath.Base(sampleOptions.ReferenceFasta)
 			sample.ReferenceFasta = &referenceFasta
+			filetype = FASTQFileType
 		}
 
 		if sampleOptions.PrimerBed != "" {
 			primerBed := filepath.Base(sampleOptions.PrimerBed)
 			sample.PrimerBed = &primerBed
+			filetype = PrimerBedFileType
 		}
 
 		for i, filename := range filenames {
 			sample.InputFileAttributes[i] = createSamplesReqInputFile{
+				FileType:	  filetype,
 				Name:         filepath.Base(filename),
 				Parts:        filepath.Base(filename),
 				Source:       filepath.Base(filename),

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -61,7 +61,7 @@ type FileType string
 const (
 	FASTQFileType FileType = "fastq"
 	PrimerBedFileType FileType = "primer_bed"
-	ReferenceAccessionFileType FileType = "reference_sequence"
+	ReferenceSequenceFileType FileType = "reference_sequence"
 )
 
 // CreateSamples creates samples on the back end and returns the necessary information to upload their files
@@ -122,13 +122,13 @@ func (c *Client) CreateSamples(
 
 		if sampleOptions.ReferenceAccession != "" {
 			sample.ReferenceAccession = &sampleOptions.ReferenceAccession
-			filetype = ReferenceAccessionFileType
+			filetype = ReferenceSequenceFileType
 		}
 
 		if sampleOptions.ReferenceFasta != "" {
 			referenceFasta := filepath.Base(sampleOptions.ReferenceFasta)
 			sample.ReferenceFasta = &referenceFasta
-			filetype = ReferenceAccessionFileType
+			filetype = ReferenceSequenceFileType
 		}
 
 		if sampleOptions.PrimerBed != "" {


### PR DESCRIPTION
CZID is going to soon require a parameter `file_type` for input files, which is a string constant defined in CZID's `InputFile` model. This PR adds the appropriate string to the `file_type` json key for each array item in `input_files`.
