### PR TITLE
Fix file_type assignment for input_files

### DIFF
--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -61,7 +61,7 @@ type FileType string
 const (
 	FASTQFileType FileType = "fastq"
 	PrimerBedFileType FileType = "primer_bed"
-	ReferenceAccessionFileType FileType = "ref_seq"
+	ReferenceAccessionFileType FileType = "reference_sequence"
 )
 
 // CreateSamples creates samples on the back end and returns the necessary information to upload their files
@@ -118,7 +118,7 @@ func (c *Client) CreateSamples(
 			sample.ClearLabs = &sampleOptions.ClearLabs
 		}
 
-		var filetype FileType
+		filetype := FASTQFileType
 
 		if sampleOptions.ReferenceAccession != "" {
 			sample.ReferenceAccession = &sampleOptions.ReferenceAccession
@@ -128,7 +128,7 @@ func (c *Client) CreateSamples(
 		if sampleOptions.ReferenceFasta != "" {
 			referenceFasta := filepath.Base(sampleOptions.ReferenceFasta)
 			sample.ReferenceFasta = &referenceFasta
-			filetype = FASTQFileType
+			filetype = ReferenceAccessionFileType
 		}
 
 		if sampleOptions.PrimerBed != "" {

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -9,7 +9,7 @@ import (
 )
 
 type createSamplesReqInputFile struct {
-	FileType	 FileType `json:"file_type"`
+	FileType	 string `json:"file_type"`
 	Name         string `json:"name"`
 	Parts        string `json:"parts"`
 	Source       string `json:"source"`

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -138,7 +138,7 @@ func (c *Client) CreateSamples(
 
 		for i, filename := range filenames {
 			sample.InputFileAttributes[i] = createSamplesReqInputFile{
-				FileType:	  filetype,
+				FileType:	  string(filetype),
 				Name:         filepath.Base(filename),
 				Parts:        filepath.Base(filename),
 				Source:       filepath.Base(filename),

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -56,6 +56,7 @@ type UploadInfo struct {
 	S3Path            string  `json:"s3_path"`
 }
 
+// Must match file type constants present in CZID's InputFile model
 type FileType string
 const (
 	FASTQFileType FileType = "fastq"

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -9,6 +9,7 @@ import (
 )
 
 type createSamplesReqInputFile struct {
+	FileType	 FileType `json:"file_type"`
 	Name         string `json:"name"`
 	Parts        string `json:"parts"`
 	Source       string `json:"source"`
@@ -54,6 +55,13 @@ type UploadInfo struct {
 	MultipartUploadId *string `json:"multipart_upload_id"`
 	S3Path            string  `json:"s3_path"`
 }
+
+type FileType string
+const (
+	FASTQFileType FileType = "fastq"
+	PrimerBedFileType FileType = "primer_bed"
+	ReferenceAccessionFileType FileType = "ref_seq"
+)
 
 // CreateSamples creates samples on the back end and returns the necessary information to upload their files
 func (c *Client) CreateSamples(
@@ -109,22 +117,28 @@ func (c *Client) CreateSamples(
 			sample.ClearLabs = &sampleOptions.ClearLabs
 		}
 
+		var filetype FileType
+
 		if sampleOptions.ReferenceAccession != "" {
 			sample.ReferenceAccession = &sampleOptions.ReferenceAccession
+			filetype = ReferenceAccessionFileType
 		}
 
 		if sampleOptions.ReferenceFasta != "" {
 			referenceFasta := filepath.Base(sampleOptions.ReferenceFasta)
 			sample.ReferenceFasta = &referenceFasta
+			filetype = FASTQFileType
 		}
 
 		if sampleOptions.PrimerBed != "" {
 			primerBed := filepath.Base(sampleOptions.PrimerBed)
 			sample.PrimerBed = &primerBed
+			filetype = PrimerBedFileType
 		}
 
 		for i, filename := range filenames {
 			sample.InputFileAttributes[i] = createSamplesReqInputFile{
+				FileType:	  filetype,
 				Name:         filepath.Base(filename),
 				Parts:        filepath.Base(filename),
 				Source:       filepath.Base(filename),

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -61,7 +61,7 @@ type FileType string
 const (
 	FASTQFileType FileType = "fastq"
 	PrimerBedFileType FileType = "primer_bed"
-	ReferenceAccessionFileType FileType = "reference_sequence"
+	ReferenceSequenceFileType FileType = "reference_sequence"
 )
 
 // CreateSamples creates samples on the back end and returns the necessary information to upload their files
@@ -122,13 +122,13 @@ func (c *Client) CreateSamples(
 
 		if sampleOptions.ReferenceAccession != "" {
 			sample.ReferenceAccession = &sampleOptions.ReferenceAccession
-			filetype = ReferenceAccessionFileType
+			filetype = ReferenceSequenceFileType
 		}
 
 		if sampleOptions.ReferenceFasta != "" {
 			referenceFasta := filepath.Base(sampleOptions.ReferenceFasta)
 			sample.ReferenceFasta = &referenceFasta
-			filetype = ReferenceAccessionFileType
+			filetype = ReferenceSequenceFileType
 		}
 
 		if sampleOptions.PrimerBed != "" {


### PR DESCRIPTION
This PR fixes a bug that incorrectly assigns file types to input files.

A bug in the logic of #43 causes the wrong `file_type` to be assigned to all files, like so:

<img width="1024" alt="Screenshot 2023-05-25 at 17 29 32" src="https://github.com/chanzuckerberg/czid-cli/assets/24234461/045baf45-39dd-43ba-9b9a-3ec2571c81d3">

With a rewrite in logic, we get the proper `file_type` assignment:

<img width="803" alt="Screenshot 2023-05-25 at 17 30 22" src="https://github.com/chanzuckerberg/czid-cli/assets/24234461/d0e1267b-715f-4d86-b5d3-0f93af3563ad">


