### PR TITLE
Make primer-bed optional for CG uploads

### DIFF
--- a/cmd/consensusGenome/consensusGenome.go
+++ b/cmd/consensusGenome/consensusGenome.go
@@ -190,10 +190,6 @@ func validateCommonArgs() error {
 		return fmt.Errorf("reference-accession can't be used if reference-fasta is set")
 	}
 
-	if (referenceAccession != "" || referenceFasta != "") && primerBed == "" {
-		return fmt.Errorf("reference-accession or reference-fasta require primer-bed")
-	}
-
 	if !(referenceAccession != "" || referenceFasta != "") && primerBed != "" {
 		return fmt.Errorf("primer-bed requires reference-accession or reference-fasta")
 	}

--- a/cmd/consensusGenome/consensusGenome.go
+++ b/cmd/consensusGenome/consensusGenome.go
@@ -136,8 +136,8 @@ func loadSharedFlags(c *cobra.Command) {
 		nanoporeDefaultWetlabProtocol,
 		defaultMedakaModel,
 	))
-	c.Flags().StringVar(&referenceAccession, "reference-accession", "", "Reference accession ID, used for general consensus genomes (not SARS-CoV2), cannot be used if reference-fasta is set, requires primer-bed and sequencing-platform 'Illumina'")
-	c.Flags().StringVar(&referenceFasta, "reference-fasta", "", "Local reference fasta file, used for general consensus genomes (not SARS-CoV2), requires primer-bed and sequencing-platform 'Illumina'")
+	c.Flags().StringVar(&referenceAccession, "reference-accession", "", "Reference accession ID, used for general consensus genomes (not SARS-CoV2), cannot be used if reference-fasta is set, requires sequencing-platform 'Illumina'")
+	c.Flags().StringVar(&referenceFasta, "reference-fasta", "", "Local reference fasta file, used for general consensus genomes (not SARS-CoV2), requires sequencing-platform 'Illumina'")
 	c.Flags().StringVar(&primerBed, "primer-bed", "", "Local primer file (.bed), used for general consensus genomes (not SARS-CoV2), requires reference-fasta or reference-accession and sequencing-platform 'Illumina'")
 	c.Flags().BoolVar(&disableBuffer, "disable-buffer", false, "Disable shared buffer pool (useful if running out of memory)")
 }
@@ -185,11 +185,9 @@ func validateCommonArgs() error {
 			return fmt.Errorf("medaka-model %s is required with clearlabs", defaultMedakaModel)
 		}
 	}
-
 	if referenceAccession != "" && referenceFasta != "" {
 		return fmt.Errorf("reference-accession can't be used if reference-fasta is set")
 	}
-
 	if !(referenceAccession != "" || referenceFasta != "") && primerBed != "" {
 		return fmt.Errorf("primer-bed requires reference-accession or reference-fasta")
 	}

--- a/cmd/consensusGenome/uploadSamples_test.go
+++ b/cmd/consensusGenome/uploadSamples_test.go
@@ -121,15 +121,13 @@ func TestReferenceReferenceFastaMissingPrimerBed(t *testing.T) {
 	ConsensusGenomeCmd.SetArgs([]string{"upload-samples", "-p", "test", "--sequencing-platform", "Illumina", "--reference-fasta", "foo.fasta"})
 	err := ConsensusGenomeCmd.Execute()
 	if err == nil {
-		t.Fatal("expected an error")
+		return
 	}
 
 	errOut, err := io.ReadAll(e)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if string(errOut) != "Error: reference-accession or reference-fasta require primer-bed\n" {
-		t.Fatalf("expected a sequencing-platform error but error was: %s", string(errOut))
+		t.Fatalf("Unexpected %s", string(errOut))
 	}
 }
 

--- a/cmd/consensusGenome/uploadSamples_test.go
+++ b/cmd/consensusGenome/uploadSamples_test.go
@@ -112,28 +112,6 @@ func TestReferenceFastaWetlabProtocol(t *testing.T) {
 	}
 }
 
-// The command should accept a reference fasta without a primer-bed argument.
-func TestReferenceReferenceFastaMissingPrimerBed(t *testing.T) {
-	resetVars()
-	b := bytes.NewBufferString("")
-	e := bytes.NewBufferString("")
-	ConsensusGenomeCmd.SetOut(b)
-	ConsensusGenomeCmd.SetErr(e)
-	ConsensusGenomeCmd.SetArgs([]string{"upload-samples", "-p", "test", "--sequencing-platform", "Illumina", "--reference-fasta", "foo.fasta"})
-	err := ConsensusGenomeCmd.Execute()
-	if err == nil {
-		return
-	}
-
-	errOut, err := io.ReadAll(e)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if errOut != nil {
-		t.Fatalf("Unexpected %s", string(errOut))
-	}
-}
-
 func TestReferencePrimerBedMissingReferenceFasta(t *testing.T) {
 	resetVars()
 	b := bytes.NewBufferString("")

--- a/cmd/consensusGenome/uploadSamples_test.go
+++ b/cmd/consensusGenome/uploadSamples_test.go
@@ -128,6 +128,8 @@ func TestReferenceReferenceFastaMissingPrimerBed(t *testing.T) {
 	errOut, err := io.ReadAll(e)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if errOut != nil {
 		t.Fatalf("Unexpected %s", string(errOut))
 	}
 }

--- a/cmd/consensusGenome/uploadSamples_test.go
+++ b/cmd/consensusGenome/uploadSamples_test.go
@@ -112,6 +112,7 @@ func TestReferenceFastaWetlabProtocol(t *testing.T) {
 	}
 }
 
+// The command should accept a reference fasta without a primer-bed argument.
 func TestReferenceReferenceFastaMissingPrimerBed(t *testing.T) {
 	resetVars()
 	b := bytes.NewBufferString("")

--- a/cmd/guidedUpload.go
+++ b/cmd/guidedUpload.go
@@ -108,7 +108,7 @@ var guidedUploadCmd = &cobra.Command{
 		var sampleName string
 		var dirname string
 		if quantity == "single" {
-			fOne := getInput(cmd, reader, "Enter R1 fielpath for a paired-end sample or filepath to single file for a single-end sample:")
+			fOne := getInput(cmd, reader, "Enter R1 filepath for a paired-end sample or filepath to single file for a single-end sample:")
 			uploadArgs = append(uploadArgs, "upload-sample", fOne)
 
 			fTwo := getInput(cmd, reader, "Enter R2 filepath for a paired-end sample or press enter for a single-end sample:")

--- a/pkg/czid/uploadSamples.go
+++ b/pkg/czid/uploadSamples.go
@@ -100,7 +100,7 @@ func (c *Client) CreateSamples(
 				Filename: StripLaneNumber(files.R2[0]),
 				FileType: FASTQFileType,
 			}
-			filesMetadata = []inputFileMetadata {metadataR1, metadataR2}
+			filesMetadata = []inputFileMetadata{metadataR1, metadataR2}
 		}
 
 		if len(files.ReferenceFasta) > 0 {


### PR DESCRIPTION
See CZID-7995.

#### Successful uploads without a primer-bed:

<img width="614" alt="Screenshot 2023-06-13 at 14 16 49" src="https://github.com/chanzuckerberg/czid-cli/assets/24234461/b2b34387-cede-47d6-bbe8-145ae5dc18d7">

<img width="811" alt="Screenshot 2023-06-13 at 14 17 04" src="https://github.com/chanzuckerberg/czid-cli/assets/24234461/e6dc08b2-603a-4ef9-9960-0a174e1b0c45">
