### PR TITLE
Update goreleaser version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean -f .goreleaser.prerelease.yml
         env:
           AUTH_0_CLIENT_ID: ${{ secrets.AUTH_0_CLIENT_ID }}
@@ -93,7 +93,7 @@ jobs:
           fetch-depth: 0
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean -f .goreleaser.yml
         env:
           AUTH_0_CLIENT_ID: ${{ secrets.AUTH_0_CLIENT_ID }}


### PR DESCRIPTION
Fixes error: `Only configurations files on version: 2 are supported, yours is version: 0, please update your configuration`